### PR TITLE
Refine the available settings for RQ_QUEUES #103

### DIFF
--- a/dejacode/settings.py
+++ b/dejacode/settings.py
@@ -411,26 +411,31 @@ FILE_UPLOAD_HANDLERS = [
     "django.core.files.uploadhandler.TemporaryFileUploadHandler",
 ]
 
-REDIS_URL = env.str("REDIS_URL", default="redis://127.0.0.1:6379")
-
 # Default setup for the cache
 # See https://docs.djangoproject.com/en/dev/topics/cache/
 CACHE_BACKEND = env.str("CACHE_BACKEND", default="django.core.cache.backends.locmem.LocMemCache")
+# Set CACHE_REDIS_URL to the URL pointing to your Redis instance available for caching,
+# using the appropriate scheme.
+# For example: "redis://[[username]:[password]]@localhost:6379/0"
+# See the redis-py docs for details on the available schemes at
+# https://redis-py.readthedocs.io/en/stable/connections.html#redis.connection.ConnectionPool.from_url
+CACHE_REDIS_URL = env.str("CACHE_REDIS_URL", default="redis://127.0.0.1:6379")
+
 CACHES = {
     "default": {
         "BACKEND": CACHE_BACKEND,
-        "LOCATION": REDIS_URL,
+        "LOCATION": CACHE_REDIS_URL,
         "TIMEOUT": 900,  # 15 minutes, in seconds
     },
     "licensing": {
         "BACKEND": CACHE_BACKEND,
-        "LOCATION": REDIS_URL,
+        "LOCATION": CACHE_REDIS_URL,
         "TIMEOUT": 300,  # 10 minutes, in seconds
         "KEY_PREFIX": "licensing",
     },
     "vulnerabilities": {
         "BACKEND": CACHE_BACKEND,
-        "LOCATION": REDIS_URL,
+        "LOCATION": CACHE_REDIS_URL,
         "TIMEOUT": 3600,  # 1 hour, in seconds
         "KEY_PREFIX": "vuln",
     },
@@ -439,10 +444,16 @@ CACHES = {
 # Job Queue
 RQ_QUEUES = {
     "default": {
-        "HOST": env.str("DEJACODE_REDIS_HOST", default="localhost"),
-        "PORT": env.str("DEJACODE_REDIS_PORT", default="6379"),
-        "PASSWORD": env.str("DEJACODE_REDIS_PASSWORD", default=""),
-        "DEFAULT_TIMEOUT": env.int("DEJACODE_RQ_DEFAULT_TIMEOUT", default=360),
+        "HOST": env.str("DEJACODE_RQ_REDIS_HOST", default="localhost"),
+        "PORT": env.str("DEJACODE_RQ_REDIS_PORT", default="6379"),
+        "DB": env.int("DEJACODE_RQ_REDIS_DB", default=0),
+        "USERNAME": env.str("DEJACODE_RQ_REDIS_USERNAME", default=None),
+        "PASSWORD": env.str("DEJACODE_RQ_REDIS_PASSWORD", default=""),
+        "DEFAULT_TIMEOUT": env.int("DEJACODE_RQ_REDIS_DEFAULT_TIMEOUT", default=360),
+        # Enable SSL for Redis connections when deploying DejaCode in environments where
+        # Redis is hosted on a separate system (e.g., cloud deployment or remote
+        # Redis server) to secure data in transit.
+        "SSL": env.bool("DEJACODE_RQ_REDIS_SSL", default=False),
     },
 }
 

--- a/docker.env
+++ b/docker.env
@@ -8,12 +8,14 @@ DATABASE_NAME=dejacode_db
 DATABASE_USER=dejacode
 DATABASE_PASSWORD=dejacode
 
-DEJACODE_REDIS_HOST=redis
+DEJACODE_RQ_REDIS_HOST=redis
 DEJACODE_ASYNC=True
 
 STATIC_ROOT=/var/dejacode/static/
 MEDIA_ROOT=/var/dejacode/media/
-REDIS_URL=redis://redis:6379
+
 CACHE_BACKEND=django.core.cache.backends.redis.RedisCache
+CACHE_REDIS_URL=redis://redis:6379
+
 CLAMD_ENABLED=True
 CLAMD_TCP_ADDR=clamav

--- a/docs/application-settings.rst
+++ b/docs/application-settings.rst
@@ -205,6 +205,32 @@ default the ``US/Pacific`` time zone is used::
     You can view a detailed list of time zones `here.
     <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>`_
 
+.. _dejacode_settings_job_queue_and_workers:
+
+Job Queue and Workers
+=====================
+
+DejaCode leverages the RQ (Redis Queue) Python library for job queuing and background
+processing with workers.
+
+By default, it is configured to use the "redis" service in the Docker Compose stack.
+
+For deployments where Redis is hosted on a separate system
+(e.g., a cloud-based deployment or a remote Redis server),
+the Redis instance used by RQ can be customized using the following settings::
+
+    DEJACODE_RQ_REDIS_HOST=localhost
+    DEJACODE_RQ_REDIS_PORT=6379
+    DEJACODE_RQ_REDIS_DB=0
+    DEJACODE_RQ_REDIS_USERNAME=<username>
+    DEJACODE_RQ_REDIS_PASSWORD=<password>
+    DEJACODE_RQ_REDIS_DEFAULT_TIMEOUT=360
+
+To enhance security, it is recommended to enable SSL for Redis connections.
+SSL is disabled by default but can be enabled with the following configuration::
+
+    DEJACODE_RQ_REDIS_SSL=True
+
 .. _dejacode_settings_aboutcode_integrations:
 
 AboutCode integrations


### PR DESCRIPTION
Changes:
- Rename `REDIS_URL` to `CACHE_REDIS_URL`
- Rename the `RQ_QUEUES` sub-settings to `DEJACODE_RQ_REDIS_*`
- Add `DEJACODE_RQ_REDIS_SSL` setting
- Add new documentation section for the "Job Queue and Workers" related settings