### PR TITLE
Fix package usage policy not getting set automatically from the license #200

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -99,6 +99,12 @@ Release notes
   the cursor for a couple seconds.
   https://github.com/aboutcode-org/dejacode/issues/243
 
+- Set the "usage_policy" in update_fields list in SetPolicyFromLicenseMixin.
+  The associated package/license policy was properly set on the model in
+  SetPolicyFromLicenseMixin but the usage_policy entry was missing from the
+  update_fields. As a result the usage_policy value was not included in the UPDATE.
+  https://github.com/aboutcode-org/dejacode/issues/200
+
 ### Version 5.2.1
 
 - Fix the models documentation navigation.

--- a/component_catalog/models.py
+++ b/component_catalog/models.py
@@ -55,6 +55,7 @@ from dejacode_toolkit.download import DataCollectionException
 from dejacode_toolkit.download import collect_package_data
 from dejacode_toolkit.purldb import PurlDB
 from dejacode_toolkit.purldb import pick_purldb_entry
+from dejacode_toolkit.scancodeio import ScanCodeIO
 from dje import urn
 from dje.copier import post_copy
 from dje.copier import post_update
@@ -2496,6 +2497,20 @@ class Package(
             override_unknown=True,
         )
         return updated_fields
+
+    def update_from_scan(self, user):
+        scancodeio = ScanCodeIO(self.dataspace)
+        can_update_from_scan = all(
+            [
+                self.dataspace.enable_package_scanning,
+                self.dataspace.update_packages_from_scan,
+                scancodeio.is_configured(),
+            ]
+        )
+
+        if can_update_from_scan:
+            updated_fields = scancodeio.update_from_scan(package=self, user=user)
+            return updated_fields
 
 
 class PackageAssignedLicense(DataspacedModel):

--- a/component_catalog/tests/test_models.py
+++ b/component_catalog/tests/test_models.py
@@ -1767,6 +1767,25 @@ class ComponentCatalogModelsTestCase(TestCase):
         for field_name, value in purldb_entry.items():
             self.assertEqual(value, getattr(package, field_name))
 
+    @mock.patch("dejacode_toolkit.scancodeio.ScanCodeIO.is_configured")
+    @mock.patch("dejacode_toolkit.scancodeio.ScanCodeIO.update_from_scan")
+    def test_package_model_update_from_scan(self, mock_update_from_scan, mock_is_configured):
+        mock_is_configured.return_value = True
+        package1 = make_package(self.dataspace)
+
+        results = package1.update_from_scan(user=self.user)
+        mock_update_from_scan.assert_not_called()
+        self.assertIsNone(results)
+
+        self.dataspace.enable_package_scanning = True
+        self.dataspace.update_packages_from_scan = True
+        self.dataspace.save()
+
+        mock_update_from_scan.return_value = ["updated_field"]
+        results = package1.update_from_scan(user=self.user)
+        mock_update_from_scan.assert_called()
+        self.assertEqual(["updated_field"], results)
+
     def test_package_model_get_url_methods(self):
         package = Package(
             filename="filename.zip",

--- a/dje/tasks.py
+++ b/dje/tasks.py
@@ -23,6 +23,7 @@ from django_rq import job
 from guardian.shortcuts import get_perms as guardian_get_perms
 
 from dejacode_toolkit.scancodeio import ScanCodeIO
+from dejacode_toolkit.scancodeio import check_for_existing_scan_workaround
 from dje.utils import is_available
 
 logger = logging.getLogger(__name__)
@@ -112,7 +113,8 @@ def scancodeio_submit_scan(uris, user_uuid, dataspace_uuid):
     scancodeio = ScanCodeIO(user.dataspace)
     for uri in uris:
         if is_available(uri):
-            scancodeio.submit_scan(uri, user_uuid, dataspace_uuid)
+            response_json = scancodeio.submit_scan(uri, user_uuid, dataspace_uuid)
+            check_for_existing_scan_workaround(response_json, uri, user)
         else:
             logger.info(f'uri="{uri}" is not reachable.')
 

--- a/license_library/tests/__init__.py
+++ b/license_library/tests/__init__.py
@@ -5,3 +5,23 @@
 # See https://github.com/aboutcode-org/dejacode for support or download.
 # See https://aboutcode.org for more information about AboutCode FOSS projects.
 #
+
+from license_library.models import License
+from organization.tests import make_owner
+
+
+def make_license(dataspace, key, **data):
+    if "owner" not in data:
+        data["owner"] = make_owner(dataspace)
+
+    if "name" not in data:
+        data["name"] = key
+
+    if "short_name" not in data:
+        data["short_name"] = key
+
+    return License.objects.create(
+        dataspace=dataspace,
+        key=key,
+        **data,
+    )

--- a/organization/tests/__init__.py
+++ b/organization/tests/__init__.py
@@ -5,3 +5,16 @@
 # See https://github.com/aboutcode-org/dejacode for support or download.
 # See https://aboutcode.org for more information about AboutCode FOSS projects.
 #
+
+from dje.tests import make_string
+from organization.models import Owner
+
+
+def make_owner(dataspace, **data):
+    if "name" not in data:
+        data["name"] = make_string(10)
+
+    return Owner.objects.create(
+        dataspace=dataspace,
+        **data,
+    )

--- a/policy/admin.py
+++ b/policy/admin.py
@@ -99,8 +99,11 @@ class UsagePolicyAdmin(ColoredIconAdminMixin, DataspacedAdmin):
     )
 
     def associated_policies(self, obj):
-        return "\n".join(
-            association.to_policy.str_with_content_type() for association in obj.to_policies.all()
+        return format_html(
+            "<br>".join(
+                association.to_policy.str_with_content_type()
+                for association in obj.to_policies.all()
+            )
         )
 
     def get_queryset(self, request):

--- a/policy/models.py
+++ b/policy/models.py
@@ -202,6 +202,8 @@ class SetPolicyFromLicenseMixin:
 
         if set_usage_policy:
             self.usage_policy = self.policy_from_primary_license
+            if "update_fields" in kwargs:
+                kwargs["update_fields"].append("usage_policy")
 
         super().save(*args, **kwargs)
 

--- a/policy/tests/__init__.py
+++ b/policy/tests/__init__.py
@@ -5,3 +5,32 @@
 # See https://github.com/aboutcode-org/dejacode for support or download.
 # See https://aboutcode.org for more information about AboutCode FOSS projects.
 #
+
+from django.contrib.contenttypes.models import ContentType
+
+from dje.tests import make_string
+from policy.models import AssociatedPolicy
+from policy.models import UsagePolicy
+
+
+def make_usage_policy(dataspace, model, **data):
+    """Create a policy for test purposes."""
+    if "label" not in data:
+        data["label"] = f"policy-{make_string(10)}"
+
+    policy = UsagePolicy.objects.create(
+        dataspace=dataspace,
+        content_type=ContentType.objects.get_for_model(model),
+        icon="icon",
+        **data,
+    )
+
+    return policy
+
+
+def make_associated_policy(from_policy, to_policy):
+    return AssociatedPolicy.objects.create(
+        from_policy=from_policy,
+        to_policy=to_policy,
+        dataspace=from_policy.dataspace,
+    )


### PR DESCRIPTION
This is likely a side effect of recent changes on the [update_from_data() ](https://github.com/aboutcode-org/dejacode/blob/d94fc4afb649ea1ece6e5a22698358bde2882d7e/dje/models.py#L816) method that builds a `update_fields` list to trigger a proper SQL UPDATE.

The associated package/license policy is properly set on the model in SetPolicyFromLicenseMixin but the `usage_policy` entry is missing from the `update_fields`. As a result the `usage_policy` value is not included in the UPDATE.


Also contains a workaround for https://github.com/aboutcode-org/dejacode/issues/30