### PR TITLE
Fix the ProductDependencyAdmin form

### DIFF
--- a/component_catalog/admin.py
+++ b/component_catalog/admin.py
@@ -63,6 +63,7 @@ from dje.filters import MissingInFilter
 from dje.filters import RelatedLookupListFilter
 from dje.list_display import AsJoinList
 from dje.list_display import AsLink
+from dje.list_display import ListDisplayItem
 from dje.list_display import AsLinkList
 from dje.list_display import AsNaturalTime
 from dje.list_display import AsURL
@@ -912,6 +913,7 @@ class PackageAdmin(
         return (
             super()
             .get_queryset(request)
+            .annotate_sortable_identifier()
             .select_related(
                 "usage_policy",
             )
@@ -1052,6 +1054,10 @@ class PackageAdmin(
         if inferred_url := obj.inferred_url:
             return urlize_target_blank(inferred_url)
         return ""
+
+    @admin.display(ordering="sortable_identifier")
+    def identifier(self, obj):
+        return obj.identifier
 
     def save_formset(self, request, form, formset, change):
         """

--- a/component_catalog/admin.py
+++ b/component_catalog/admin.py
@@ -63,7 +63,6 @@ from dje.filters import MissingInFilter
 from dje.filters import RelatedLookupListFilter
 from dje.list_display import AsJoinList
 from dje.list_display import AsLink
-from dje.list_display import ListDisplayItem
 from dje.list_display import AsLinkList
 from dje.list_display import AsNaturalTime
 from dje.list_display import AsURL
@@ -775,7 +774,17 @@ class PackageAdmin(
         "get_dataspace",
     )
     list_display_links = ("identifier",)
-    search_fields = ("filename", "download_url", "project")
+    search_fields = (
+        "type",
+        "namespace",
+        "name",
+        "version",
+        "filename",
+        "download_url",
+        "sha1",
+        "md5",
+        "project",
+    )
     ordering = ("-last_modified_date",)
     list_filter = (
         ("component", HierarchyRelatedLookupListFilter),
@@ -939,6 +948,16 @@ class PackageAdmin(
         ]
 
         return urls + super().get_urls()
+
+    def get_search_results(self, request, queryset, search_term):
+        """Add searching on provided PackageURL identifier."""
+        use_distinct = False
+
+        is_purl = "/" in search_term
+        if is_purl:
+            return queryset.for_package_url(search_term), use_distinct
+
+        return super().get_search_results(request, queryset, search_term)
 
     def changeform_view(self, request, object_id=None, form_url="", extra_context=None):
         """

--- a/dejacode/static/css/dejacode_bootstrap.css
+++ b/dejacode/static/css/dejacode_bootstrap.css
@@ -426,19 +426,22 @@ table.vulnerabilities-table .column-summary {
 
 /* -- Dependency tab -- */
 #tab_dependencies .column-for_package {
-  width: 250px;
+  min-width: 300px;
 }
 #tab_dependencies .column-resolved_to_package {
-  width: 250px;
+  min-width: 300px;
 }
 #tab_dependencies .column-is_runtime {
-  width: 100px;
+  width: 85px;
+  font-size: 0.75rem;
 }
-#tab_dependencies .column-column-is_optional {
-  width: 100px;
+#tab_dependencies .column-is_optional {
+  width: 85px;
+  font-size: 0.75rem;
 }
-#tab_dependencies .column-column-is_pinned {
-  width: 88px;
+#tab_dependencies .column-is_pinned {
+  width: 80px;
+  font-size: 0.75rem;
 }
 
 /* -- Package Details -- */
@@ -661,7 +664,6 @@ td.sub-header {
 .table thead tr th a.sort:hover {
   color: #ccc;
   text-decoration: none;
-  margin-left: 0;
 }
 .table thead tr th a.sort.active {
   color: var(--bs-body-color);

--- a/dje/templates/includes/object_list_table_header.html
+++ b/dje/templates/includes/object_list_table_header.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% spaceless %}
 <thead class="text-break-initial">
   <tr>
     {% if is_grouping_active %}
@@ -27,10 +28,10 @@
           {% with query_no_sort=filter.get_query_no_sort %}
             {% if filter.form.sort.data and header.field_name in filter.form.sort.data.0 %}
               {# The sort for this field is currently active #}
-              <a href="?{% if query_no_sort %}{{ query_no_sort }}&{% endif %}{% if tab_id %}{{ tab_id }}-{% endif %}sort={% if '-' not in filter.form.sort.data.0 %}-{% endif %}{{ header.field_name }}{% if tab_id %}#{{ tab_id }}{% endif %}" class="sort active" aria-label="Sort"><i class="fas fa-sort-{% if '-' not in filter.form.sort.data.0 %}up{% else %}down{% endif %}"></i></a>
+              <a href="?{% if query_no_sort %}{{ query_no_sort }}&{% endif %}{% if tab_id %}{{ tab_id }}-{% endif %}sort={% if '-' not in filter.form.sort.data.0 %}-{% endif %}{{ header.field_name }}{% if tab_id %}#{{ tab_id }}{% endif %}" class="sort active ms-1" aria-label="Sort"><i class="fas fa-sort-{% if '-' not in filter.form.sort.data.0 %}up{% else %}down{% endif %}"></i></a>
             {% else %}
               {# The sort for this field is NOT active #}
-              <a href="?{% if query_no_sort %}{{ query_no_sort }}&{% endif %}{% if tab_id %}{{ tab_id }}-{% endif %}sort={{ header.field_name }}{% if tab_id %}#{{ tab_id }}{% endif %}" class="sort" aria-label="Sort"><i class="fas fa-sort"></i></a>
+              <a href="?{% if query_no_sort %}{{ query_no_sort }}&{% endif %}{% if tab_id %}{{ tab_id }}-{% endif %}sort={{ header.field_name }}{% if tab_id %}#{{ tab_id }}{% endif %}" class="sort ms-1" aria-label="Sort"><i class="fas fa-sort"></i></a>
             {% endif %}
           {% endwith %}
         {% endif %}
@@ -41,3 +42,4 @@
     {% endif %}
   </tr>
 </thead>
+{% endspaceless %}

--- a/product_portfolio/admin.py
+++ b/product_portfolio/admin.py
@@ -814,6 +814,28 @@ class ProductDependencyAdmin(ProductRelatedAdminMixin):
         "is_direct",
         "get_dataspace",
     )
+    fieldsets = (
+        (None, {"fields": ["product"]}),
+        (
+            None,
+            {
+                "fields": [
+                    "dependency_uid",
+                    "for_package",
+                    "resolved_to_package",
+                    "declared_dependency",
+                    "extracted_requirement",
+                    "scope",
+                    "datasource_id",
+                    "is_runtime",
+                    "is_optional",
+                    "is_pinned",
+                    "is_direct",
+                ]
+            },
+        ),
+        get_additional_information_fieldset(),
+    )
     raw_id_fields = [
         "product",
         "for_package",
@@ -832,6 +854,7 @@ class ProductDependencyAdmin(ProductRelatedAdminMixin):
         ReportingQueryListFilter,
     )
     actions_to_remove = ["copy_to", "compare_with"]
+    form = ProductRelatedAdminForm
 
     def get_queryset(self, request):
         return (

--- a/product_portfolio/models.py
+++ b/product_portfolio/models.py
@@ -1602,7 +1602,6 @@ class ProductDependency(HistoryFieldsMixin, DataspacedModel):
         related_name="declared_dependencies",
         help_text=_("The package that declares this dependency."),
         on_delete=models.CASCADE,
-        editable=False,
         blank=True,
         null=True,
     )
@@ -1614,7 +1613,6 @@ class ProductDependency(HistoryFieldsMixin, DataspacedModel):
             "If empty, it indicates the dependency is unresolved."
         ),
         on_delete=models.SET_NULL,
-        editable=False,
         blank=True,
         null=True,
     )


### PR DESCRIPTION
Changes for #286:
- Fix the ProductDependencyAdmin form to edit and create new objects 
- Refine the Dependency tab rendering
- Add the ability to sort by `identifier` in Package admin list
- Add search by PackageURL in the Package admin