### PR TITLE
Add a new "Package Set" tab to the Package details view #276

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -149,6 +149,10 @@ Release notes
   merged and kept for the data update.
   https://github.com/aboutcode-org/dejacode/issues/303
 
+- Add a new "Package Set" tab to the Package details view.
+  This tab displays related packages grouped by their normalized ("plain") Package URL.
+  https://github.com/aboutcode-org/dejacode/issues/276
+
 ### Version 5.2.1
 
 - Fix the models documentation navigation.

--- a/component_catalog/templates/component_catalog/tabs/tab_package_set.html
+++ b/component_catalog/templates/component_catalog/tabs/tab_package_set.html
@@ -1,0 +1,41 @@
+{% load i18n %}
+{% spaceless %}
+<table class="table table-bordered table-hover table-md text-break">
+  <thead>
+    <tr>
+      <th>{% trans 'Package URL' %}</th>
+      <th>{% trans 'Filename' %}</th>
+      <th>{% trans 'Download URL' %}</th>
+      <th>{% trans 'Concluded license' %}</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for package in values %}
+      <tr data-uuid="{{ package.uuid }}">
+        <td class="fw-bold">
+          {% if package.uuid == object.uuid %}
+            {{ package.package_url }}
+            <div>
+              <span class="badge bg-secondary">Current package</span>
+            </div>
+          {% else %}
+            <a href="{{ package.get_absolute_url }}" target="_blank">
+              {{ package.package_url }}
+            </a>
+          {% endif %}
+        </td>
+        <td>{{ package.filename|default_if_none:"" }}</td>
+        <td>
+          {% if package.download_url %}
+            <i class="fa-solid fa-download me-1"></i>
+            {{ package.download_url|urlize }}
+          {% endif %}
+        </td>
+        <td>
+          {{ package.license_expression_linked|default_if_none:"" }}
+        </td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endspaceless %}

--- a/component_catalog/tests/test_models.py
+++ b/component_catalog/tests/test_models.py
@@ -2709,3 +2709,32 @@ class ComponentCatalogModelsTestCase(TestCase):
         package2 = make_package(self.dataspace)
         self.assertTrue(package1.is_vulnerable)
         self.assertFalse(package2.is_vulnerable)
+
+    def test_package_queryset_has_package_url(self):
+        package1 = make_package(self.dataspace, package_url="pkg:pypi/django@5.0")
+        make_package(self.dataspace)
+        qs = Package.objects.has_package_url()
+        self.assertQuerySetEqual(qs, [package1])
+
+    def test_package_queryset_annotate_sortable_identifier(self):
+        package1 = make_package(self.dataspace, package_url="pkg:pypi/django@5.0")
+        package2 = make_package(self.dataspace)
+        qs = Package.objects.annotate_sortable_identifier()
+        self.assertEqual("pypidjango5.0", qs.get(pk=package1.pk).sortable_identifier)
+        self.assertEqual(package2.filename, qs.get(pk=package2.pk).sortable_identifier)
+
+    def test_package_queryset_annotate_package_url(self):
+        package_url = "pkg:pypi/django@5.0?qualifier=true#path"
+        package1 = make_package(self.dataspace, package_url=package_url)
+        package2 = make_package(self.dataspace)
+        qs = Package.objects.annotate_package_url()
+        self.assertEqual(package_url, qs.get(pk=package1.pk).purl)
+        self.assertEqual("", qs.get(pk=package2.pk).purl)
+
+    def test_package_queryset_annotate_plain_package_url(self):
+        package_url = "pkg:pypi/django@5.0?qualifier=true#path"
+        package1 = make_package(self.dataspace, package_url=package_url)
+        package2 = make_package(self.dataspace)
+        qs = Package.objects.annotate_plain_package_url()
+        self.assertEqual("pkg:pypi/django@5.0", qs.get(pk=package1.pk).plain_purl)
+        self.assertEqual("", qs.get(pk=package2.pk).plain_purl)

--- a/component_catalog/tests/test_models.py
+++ b/component_catalog/tests/test_models.py
@@ -2693,6 +2693,20 @@ class ComponentCatalogModelsTestCase(TestCase):
         package_no_download_url.refresh_from_db()
         self.assertEqual(purldb_entry["description"], package_no_download_url.description)
 
+    def test_package_model_get_related_packages_qs(self):
+        package_url = "pkg:pypi/django@5.0"
+        package1 = make_package(self.dataspace, package_url=package_url)
+        related_packages_qs = package1.get_related_packages_qs()
+        self.assertQuerySetEqual(related_packages_qs, [package1])
+
+        package2 = make_package(
+            self.dataspace,
+            package_url=package_url,
+            filename="Django-5.0.tar.gz",
+        )
+        related_packages_qs = package1.get_related_packages_qs()
+        self.assertQuerySetEqual(related_packages_qs, [package1, package2])
+
     def test_package_model_vulnerability_queryset_mixin(self):
         package1 = make_package(self.dataspace, is_vulnerable=True)
         package2 = make_package(self.dataspace)

--- a/component_catalog/views.py
+++ b/component_catalog/views.py
@@ -65,6 +65,7 @@ from component_catalog.forms import SetPolicyForm
 from component_catalog.license_expression_dje import get_dataspace_licensing
 from component_catalog.license_expression_dje import get_formatted_expression
 from component_catalog.license_expression_dje import get_unique_license_keys
+from component_catalog.models import PACKAGE_URL_FIELDS
 from component_catalog.models import Component
 from component_catalog.models import Package
 from component_catalog.models import PackageAlreadyExistsWarning
@@ -1144,6 +1145,7 @@ class PackageDetailsView(
             ],
         },
         "product_usage": {},
+        "package_set": {},
         "activity": {},
         "external_references": {
             "fields": [
@@ -1296,6 +1298,24 @@ class PackageDetailsView(
             return
 
         return {"fields": fields}
+
+    def tab_package_set(self):
+        related_packages_qs = self.object.get_related_packages_qs()
+        if related_packages_qs is None:
+            return
+
+        related_packages = related_packages_qs.only(
+            "uuid",
+            *PACKAGE_URL_FIELDS,
+            "filename",
+            "download_url",
+            "license_expression",
+            "dataspace__name",
+        ).prefetch_related("licenses")
+
+        template = "component_catalog/tabs/tab_package_set.html"
+        if len(related_packages) > 1:
+            return {"fields": [(None, related_packages, None, template)]}
 
     def tab_product_usage(self):
         user = self.request.user

--- a/dje/tests/test_permissions.py
+++ b/dje/tests/test_permissions.py
@@ -110,6 +110,7 @@ class DejaCodePermissionTestCase(TestCase):
                 "others",
                 "components",
                 "product_usage",
+                "package_set",
                 "activity",
                 "external_references",
                 "usage_policy",

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     wheel==0.45.1
     pip==25.0.1
     # Django
-    Django==5.1.8
+    Django==5.1.9
     asgiref==3.8.1
     typing_extensions==4.12.2
     sqlparse==0.5.3


### PR DESCRIPTION
This PR contains the working parts of https://github.com/aboutcode-org/dejacode/pull/301

It adds a new "Package Set" tab to the Package details view.
This tab displays related packages grouped by their normalized ("plain") Package URL.

This implementation is purely based on QuerySet and does not include any model changes.