### PR TITLE
Replace the hardcoded /var/www/html by named volume #157

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,17 @@ Release notes
   https://github.com/aboutcode-org/dejacode/pull/315
   https://github.com/aboutcode-org/dejacode/pull/312
 
+- Replace the hardcoded ``/var/www/html`` by a ``webroot`` named volume in
+  ``docker-compose.yml``.
+  In the Docker compose ``nginx`` service, the hardcoded ``/var/www/html`` was declared
+  as a volume which would cause issues when the ``/var/`` was not available on the
+  local machine.
+  The Docker volume directory ``/var/lib/docker/volumes/dejacode_webroot/_data`` can
+  now be used in place of ``/var/www/html`` as the ``certbot --webroot-path`` for
+  HTTP certificates management.
+  https://github.com/aboutcode-org/dejacode/issues/157
+  https://github.com/aboutcode-org/dejacode/pull/322
+
 - Add REST API "actions" in package endpoint to track the scan status and fetch results:
   * `/packages/{uuid}/scan_info/` Scan information including the current status.
   * `/packages/{uuid}/scan_results/` Scan results.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
     volumes:
       - ./etc/nginx/conf.d/:/etc/nginx/conf.d/
       - static:/var/dejacode/static/
-      - webroot:/var/www/letsencrypt/
+      - webroot:/var/www/html/
     depends_on:
       - web
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,8 +86,8 @@ services:
       - "${NGINX_PUBLISHED_HTTPS_PORT:-443}:443"
     volumes:
       - ./etc/nginx/conf.d/:/etc/nginx/conf.d/
-      - /var/www/html:/var/www/html
       - static:/var/dejacode/static/
+      - webroot:/var/www/letsencrypt/
     depends_on:
       - web
     restart: always
@@ -107,3 +107,4 @@ volumes:
   clamav_data:
   static:
   media:
+  webroot:


### PR DESCRIPTION
https://github.com/aboutcode-org/dejacode/issues/157

Replace the hardcoded ``/var/www/html`` by a ``webroot`` named volume in ``docker-compose.yml``.

In the Docker compose ``nginx`` service, the hardcoded ``/var/www/html`` was declared
as a volume which would cause issues when the ``/var/`` was not available on the
local machine.

The Docker volume directory ``/var/lib/docker/volumes/dejacode_webroot/_data`` can
now be used in place of ``/var/www/html`` as the ``certbot --webroot-path`` for
HTTP certificate management.