### PR TITLE
fix: revert RQ to working version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ dependencies = [
     # Testing
     "model_bakery==1.23.3",
     # Task queue
-    "rq==2.10.0",
+    "rq==2.9.0",
     "croniter==6.2.3",
     "django-rq==3.2.2",
     "fakeredis==2.36.2",

--- a/uv.lock
+++ b/uv.lock
@@ -376,10 +376,10 @@ requires-dist = [
     { name = "requests", specifier = "==2.34.2" },
     { name = "requests-oauthlib", specifier = "==2.0.0" },
     { name = "rpds-py", specifier = "==0.30.0" },
-    { name = "rq", specifier = "==2.10.0" },
+    { name = "rq", specifier = "==2.9.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.14" },
     { name = "saneyaml", specifier = "==0.6.1" },
-    { name = "semantic-version", specifier = "==2.10.0" },
+    { name = "semantic-version", specifier = "==2.9.0" },
     { name = "setuptools", specifier = "==83.0.0" },
     { name = "setuptools-rust", specifier = "==1.12.0" },
     { name = "setuptools-scm", specifier = "==9.2.2" },
@@ -1009,7 +1009,7 @@ wheels = [
 
 [[package]]
 name = "rq"
-version = "2.10.0"
+version = "2.9.0"
 source = { registry = "thirdparty/dist" }
 dependencies = [
     { name = "click" },
@@ -1017,7 +1017,7 @@ dependencies = [
     { name = "redis" },
 ]
 wheels = [
-    { path = "rq-2.10.0-py3-none-any.whl" },
+    { path = "rq-2.9.0-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -1042,10 +1042,10 @@ wheels = [
 
 [[package]]
 name = "semantic-version"
-version = "2.10.0"
+version = "2.9.0"
 source = { registry = "thirdparty/dist" }
 wheels = [
-    { path = "semantic_version-2.10.0-py2.py3-none-any.whl" },
+    { path = "semantic_version-2.9.0-py2.py3-none-any.whl" },
 ]
 
 [[package]]


### PR DESCRIPTION
```
scheduler-1  | Loading cron configuration from dje.cron_jobs
scheduler-1  | 15:10:46 Loading cron configuration from dje.cron_jobs
scheduler-1  | 15:10:46 Failed to register job update_vulnerabilities from config: DjangoCronScheduler.register() got an unexpected keyword argument 'name'
scheduler-1  | Traceback (most recent call last):
scheduler-1  |   File "/opt/dejacode/.venv/lib/python3.14/site-packages/rq/cron.py", line 498, in load_config_from_file
scheduler-1  |     self.register(**data)  # Calls the instance's register method
scheduler-1  |     ~~~~~~~~~~~~~^^^^^^^^
scheduler-1  | TypeError: DjangoCronScheduler.register() got an unexpected keyword argument 'name'
scheduler-1  | 15:10:46 Failed to register job evaluate_all_products_rules_task from config: DjangoCronScheduler.register() got an unexpected keyword argument 'name'
scheduler-1  | Traceback (most recent call last):
scheduler-1  |   File "/opt/dejacode/.venv/lib/python3.14/site-packages/rq/cron.py", line 498, in load_config_from_file
scheduler-1  |     self.register(**data)  # Calls the instance's register method
scheduler-1  |     ~~~~~~~~~~~~~^^^^^^^^
scheduler-1  | TypeError: DjangoCronScheduler.register() got an unexpected keyword argument 'name'
scheduler-1  | 15:10:46 Failed to register job evaluate_all_products_vulnerability_triage_task from config: DjangoCronScheduler.register() got an unexpected keyword argument 'name'
scheduler-1  | Traceback (most recent call last):
scheduler-1  |   File "/opt/dejacode/.venv/lib/python3.14/site-packages/rq/cron.py", line 498, in load_config_from_file
scheduler-1  |     self.register(**data)  # Calls the instance's register method
scheduler-1  |     ~~~~~~~~~~~~~^^^^^^^^
scheduler-1  | TypeError: DjangoCronScheduler.register() got an unexpected keyword argument 'name'
scheduler-1  | 15:10:46 Successfully registered 0 cron jobs from 'dje.cron_jobs'
```